### PR TITLE
Fix gettext alias, jingo test project settings and add alias for 18n

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,9 +35,9 @@ In ``settings.py`` add Puente to ``INSTALLED_APPS``:
    ]
 
 
-In ``settings.py`` add ``puente.ext.PuenteI18nExtension`` as an extension
-in your Jinja2 template environment configuration. For example, if you were
-using django-jinja, then it might look like this:
+In ``settings.py`` add ``puente.ext.i18n`` as an extension in your Jinja2
+template environment configuration. For example, if you were using django-jinja,
+then it might look like this:
 
 .. code-block:: python
 
@@ -49,7 +49,7 @@ using django-jinja, then it might look like this:
                 # ...
                 'extensions': [
                     # ...
-                    'puente.ext.PuenteI18nExtension',
+                    'puente.ext.i18n',
                     # ...
                 ],
            },
@@ -253,7 +253,7 @@ Note that ``BASE_DIR`` is the path to the project root. It's in the
                   'django_jinja.builtins.extensions.CsrfExtension',
                   'django_jinja.builtins.extensions.StaticFilesExtension',
                   'django_jinja.builtins.extensions.DjangoFiltersExtension',
-                  'puente.ext.PuenteI18nExtension',
+                  'puente.ext.i18n',
               ]
           }
       }
@@ -278,7 +278,7 @@ Note that ``BASE_DIR`` is the path to the project root. It's in the
                    # ...
                    'extensions': [
                        # ...
-                       'puente.ext.PuenteI18nExtension',
+                       'puente.ext.i18n',
                        # ...
                    ],
               }
@@ -294,7 +294,7 @@ Note that ``BASE_DIR`` is the path to the project root. It's in the
          'JINJA_CONFIG': {
             'extensions': [
                 # ...
-                'puente.ext.PuenteI18nExtension',
+                'puente.ext.i18n',
                 # ...
             ],
             'silent': 'False'

--- a/puente/ext.py
+++ b/puente/ext.py
@@ -5,10 +5,10 @@ from puente.utils import collapse_whitespace
 
 
 @jinja2.contextfunction
-def _gettext_alias(context, text, *args, **kwargs):
+def _gettext_alias(__context, *args, **kwargs):
     """Marks result of gettext as 'safe'"""
     return jinja2.Markup(
-        context.resolve('gettext')(context, text, *args, **kwargs)
+        __context.call(__context.resolve('gettext'), *args, **kwargs)
     )
 
 
@@ -35,3 +35,6 @@ class PuenteI18nExtension(InternationalizationExtension):
         parse_block = InternationalizationExtension._parse_block
         ref, buffer = parse_block(self, parser, allow_pluralize)
         return ref, collapse_whitespace(buffer)
+
+
+i18n = PuenteI18nExtension

--- a/test_project_django_jinja/test_project/settings.py
+++ b/test_project_django_jinja/test_project/settings.py
@@ -52,7 +52,7 @@ TEMPLATES = [
                 'django_jinja.builtins.extensions.CsrfExtension',
                 'django_jinja.builtins.extensions.StaticFilesExtension',
                 'django_jinja.builtins.extensions.DjangoFiltersExtension',
-                'puente.ext.PuenteI18nExtension',
+                'puente.ext.i18n',
             ]
         }
     },

--- a/test_project_jingo/test_project/settings.py
+++ b/test_project_jingo/test_project/settings.py
@@ -46,10 +46,13 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 def JINJA_CONFIG():
     config = {
         'extensions': [
+            # Need this even though Puente's i18n extension stomps on it
+            # because otherwise Jingo doesn't work right.
+            'jinja2.ext.i18n',
             'jinja2.ext.with_',
             'jinja2.ext.loopcontrols',
             'jinja2.ext.autoescape',
-            'puente.ext.PuenteI18nExtension',
+            'puente.ext.i18n',
         ],
         'finalize': lambda x: x if x is not None else ''
     }

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -41,7 +41,7 @@ def build_environment(template):
         autoescape=True,
         loader=DictLoader({'tmpl.html': template}),
         extensions=[
-            'puente.ext.PuenteI18nExtension'
+            'puente.ext.i18n'
         ]
     )
     env.install_gettext_callables(gettext, ngettext, newstyle=True)


### PR DESCRIPTION
This fixes the gettext alias so that it has the correct number of
arguments.

This undoes 3264309 which changed the jingo test project settings to
not add 'jingo.ext.i18n' to the beginning of the extensions list with
the theory that we don't need it since the
'puente.ext.PuenteI18nExtension' stomps on it later. However, it turns
out Jingo explicitly looks for 'jinja2.ext.i18n' in the extensions
list and does stuff based on that. Awesome. So this readds that line
with a note about why it's there.

Further, I got tired of typing PuenteI18nExtension and added an i18n
alias just like Jinja2 has.

Fixes #35 
