### PR TITLE
Support Django<=1.11 (was: Migrate to parser.add_arguments())

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: python
 sudo: false
 python:
     - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 install:
-    - pip install tox
+    - pip install tox-travis
 script:
     - tox
-env:
-    - TOXENV=py27_dj18_django_jinja
-    - TOXENV=py34_dj18_django_jinja
-    - TOXENV=py35_dj18_django_jinja
-    - TOXENV=py36_dj18_django_jinja

--- a/puente/management/commands/extract.py
+++ b/puente/management/commands/extract.py
@@ -10,18 +10,18 @@ from puente.settings import get_setting
 class Command(BaseCommand):
     help = 'Extracts strings for translation.'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--output-dir', '-o',
             default=os.path.join(get_setting('BASE_DIR'), 'locale',
                                  'templates', 'LC_MESSAGES'),
             dest='outputdir',
             help=(
                 'The directory where extracted files will be placed. '
-                '(Default: %default)'
+                '(Default: %%default)'
             )
         ),
-    )
+
     requires_system_checks = False
 
     def handle(self, *args, **options):

--- a/puente/management/commands/merge.py
+++ b/puente/management/commands/merge.py
@@ -26,18 +26,18 @@ class Command(BaseCommand):
     compendium will be used by gettext for fuzzy matching.
 
     """
-    option_list = BaseCommand.option_list + (
-        make_option(
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '-c', '--create',
             action='store_true', dest='create', default=False,
             help='Create locale subdirectories'
         ),
-        make_option(
+        parser.add_argument(
             '-b', '--backup',
             action='store_true', dest='backup', default=False,
             help='Create backup files of .po files'
         ),
-    )
 
     def handle(self, *args, **options):
         return merge_command(

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,27 @@
 [tox]
-envlist =
-    py27_dj18_django_jinja,
-    py34_dj18_django_jinja,
-    py35_dj18_django_jinja,
-    py36_dj18_django_jinja
+envlist = py{27,34,35}-django{18,19,110}, py36-django111
+       
 
 [testenv]
 setenv =
+    PYTHONWARNINGS=default
     PYTHONPATH = {toxinidir}:{toxinidir}/puente
 
-commands = py.test
+basepython = 
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
 
 deps =
     pytest
     pytest-pythonpath
     pytest-django
-
-[testenv:py27_dj18_django_jinja]
-basepython = python2.7
-deps =
-    Django<1.9
     django-jinja
-    {[testenv]deps}
+	django18: Django<1.9
+	django19: Django<1.10
+	django110: Django<1.11
+	django111: Django<1.11b1
 
-[testenv:py34_dj18_django_jinja]
-basepython = python3.4
-deps =
-    Django<1.9
-    django-jinja
-    {[testenv]deps}
+commands = py.test
 
-[testenv:py35_dj18_django_jinja]
-basepython = python3.5
-deps =
-    Django<1.9
-    django-jinja
-    {[testenv]deps}
-
-[testenv:py36_dj18_django_jinja]
-basepython = python3.6
-deps =
-    Django<1.9
-    django-jinja
-    {[testenv]deps}


### PR DESCRIPTION
Uses parser.add_arguments() as the previous approach has been deprecated
since 1.8.

Fixes #59.

A possibly downside is that [with the change](https://docs.djangoproject.com/en/1.10/releases/1.8/#extending-management-command-arguments-through-command-option-list), I have not implemented a solution to allow Django<1.8 to work. 

*Secondary thoughts*: perhaps it'd be better to stop supporting 1.7, seeing as it is not a supported version anymore, and furthermore add test environments for 1.10 and 1.11 while at it?

*Ternary thoughts*: Should this PR be a PR to remove support for 1.7, whilst adding it for 1.10 and 1.11?