### PR TITLE
Remove compendia refs from help for merge command

### DIFF
--- a/puente/management/commands/merge.py
+++ b/puente/management/commands/merge.py
@@ -18,13 +18,6 @@ class Command(BaseCommand):
     guarantees that the newly created PO file has proper gettext
     metadata headers.
 
-    During merging (or initializing), the command will also look in
-    `locale/compendia` for a locale-specific compendium of
-    translations (serving as a translation memory of sorts). The
-    compendium file must be called `${locale}.compendium`,
-    e.g. `es_ES.compendium` for Spanish.  The translations in the
-    compendium will be used by gettext for fuzzy matching.
-
     """
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Tower supported initializing strings from a [compendia](https://www.gnu.org/software/gettext/manual/html_node/Compendium.html#Compendium) (a collection of translated strings in the .po format), but it was dropped in Puente. Most references were removed in 2015 (issue #17), but this paragraph was missed. The merge command does support the other documented operations (initializing a new file, etc.).

I was able to use a compedium by calling ``gettext`` commands directly. My use case is so rare that it makes sense for Puente to drop support for it.

This PR should fix #66.